### PR TITLE
ci: improve Dockerfile with slimmer image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.*
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM node:18.16.0-alphine
-FROM mcr.microsoft.com/playwright:v1.35.0-jammy
+FROM node:18.16-slim
 
-CMD ["npm", "install", "-g", "npm@9.6.7"]
-
-RUN mkdir /app
 WORKDIR /app
+COPY  package.json package-lock.json ./
+RUN npm install --strict-peer-deps --loglevel verbose && \
+    rm -rf /root/.cache && rm -rf /root/.npm
 COPY . /app
-
-RUN npm i
 
 CMD ["npx", "ts-node", "app.ts"]


### PR DESCRIPTION
Dockerfile 크기를 좀 많이 줄여봤습니다.

기존 3GB -> 개선 400MB

잘 작동하는 것 같기는 한데 memphis 접속정보가 없어서 playwright 같은것도 정상작동 하는지 검증은 못했습니다.

